### PR TITLE
LITE-24585 Add support to enable and disable questions

### DIFF
--- a/interrogatio/core/dialog.py
+++ b/interrogatio/core/dialog.py
@@ -39,7 +39,8 @@ def show_dialog(
         return
     answers = {}
     for handler in handlers:
-        answers.update(handler.get_answer())
+        if not handler.is_disabled(answers):
+            answers.update(handler.get_answer())
     return answers
 
 

--- a/interrogatio/core/prompt.py
+++ b/interrogatio/core/prompt.py
@@ -54,6 +54,8 @@ def interrogatio(questions, theme='default'):
     validate_questions(questions)
     for q in questions:
         handler = get_instance(q)
+        if handler.is_disabled(context=answers):
+            continue
         handler.set_context(answers)
         layout = handler.get_layout()
         layout.align = HorizontalAlign.LEFT

--- a/interrogatio/core/utils.py
+++ b/interrogatio/core/utils.py
@@ -72,6 +72,10 @@ def _validate_question(q):  # noqa: CCR001
                 validator_instances.append(v)
         q['validators'] = validator_instances
 
+    if 'disabled' in q:
+        if not (isinstance(q['disabled'], bool) or callable(q['disabled'])):
+            raise InvalidQuestionError('Disabled flag must be a boolean or callable.')
+
 
 def validate_questions(questions):
     for q in questions:

--- a/interrogatio/core/utils.py
+++ b/interrogatio/core/utils.py
@@ -74,7 +74,9 @@ def _validate_question(q):  # noqa: CCR001
 
     if 'disabled' in q:
         if not (isinstance(q['disabled'], bool) or callable(q['disabled'])):
-            raise InvalidQuestionError('Disabled flag must be a boolean or callable.')
+            raise InvalidQuestionError(
+                'Disabled flag must be a boolean or callable.',
+            )
 
 
 def validate_questions(questions):

--- a/interrogatio/handlers/base.py
+++ b/interrogatio/handlers/base.py
@@ -21,7 +21,6 @@ class QHandler(metaclass=ABCMeta):
         self._question = question
         self._widget = None
         self._errors = []
-        self.disabled = True
 
     @property
     def errors(self):
@@ -165,11 +164,9 @@ class QHandler(metaclass=ABCMeta):
         """
         disabled = self._question.get('disabled', False)
         if callable(disabled):
-            self.disabled = disabled(context)
+            return disabled(context)
         else:
-            self.disabled = disabled
-
-        return self.disabled
+            return disabled
 
     def is_valid(self, context=None):
         """

--- a/interrogatio/handlers/base.py
+++ b/interrogatio/handlers/base.py
@@ -157,6 +157,17 @@ class QHandler(metaclass=ABCMeta):
             'label', self.get_variable_name().capitalize(),
         )
 
+    def is_disabled(self, context=None):
+        """
+        If disabled flag specified, it is evaluated if needed and returned.
+        By default, all questions are enabled.
+        """
+        disabled = self._question.get('disabled', False)
+        if callable(disabled):
+            return disabled(context)
+        else:
+            return disabled
+
     def is_valid(self, context=None):
         """
         Apply any speficied validator to the answer and return True if the

--- a/interrogatio/handlers/base.py
+++ b/interrogatio/handlers/base.py
@@ -21,6 +21,7 @@ class QHandler(metaclass=ABCMeta):
         self._question = question
         self._widget = None
         self._errors = []
+        self.disabled = True
 
     @property
     def errors(self):
@@ -164,9 +165,11 @@ class QHandler(metaclass=ABCMeta):
         """
         disabled = self._question.get('disabled', False)
         if callable(disabled):
-            return disabled(context)
+            self.disabled = disabled(context)
         else:
-            return disabled
+            self.disabled = disabled
+
+        return self.disabled
 
     def is_valid(self, context=None):
         """

--- a/interrogatio/themes/theme_files/default.json
+++ b/interrogatio/themes/theme_files/default.json
@@ -31,6 +31,7 @@
       "dialog.body shadow": "bg:#aaaaaa",
       "dialog.step": "bg:#ffffff",
       "dialog.step.current": "bg:#ffffff magenta bold",
+      "dialog.step.disabled": "bg:#ffffff grey",
       "button": "",
       "button.arrow": "bold",
       "button.focused": "bg:#aa0000 #ffffff",

--- a/interrogatio/themes/theme_files/purple.json
+++ b/interrogatio/themes/theme_files/purple.json
@@ -31,6 +31,7 @@
       "dialog.body shadow": "bg:magenta",
       "dialog.step": "",
       "dialog.step.current": "magenta bold",
+      "dialog.step.disabled": "grey",
       "button": "white",
       "button.arrow": "bold",
       "button.focused": "bg:magenta white",

--- a/interrogatio/widgets/wizard.py
+++ b/interrogatio/widgets/wizard.py
@@ -249,6 +249,18 @@ class WizardDialog:
                 },
             )
 
+    def enabled_steps_left(self):
+        idx = self.current_step_idx + 1
+        while idx <= len(self.steps) - 1:
+            next_step = self.steps[idx]
+            next_handler = next_step['handler']
+            if next_handler:
+                if not next_handler.disabled:
+                    return True
+            idx += 1
+
+        return False
+
     def set_buttons_labels(self):
         if len(self.steps) == 1:
             return
@@ -257,8 +269,10 @@ class WizardDialog:
             return
         if self.current_step_idx == len(self.steps) - 1:
             self.next_btn.text = self.label_finish
-        else:
+        elif self.enabled_steps_left():
             self.next_btn.text = self.label_next
+        else:
+            self.next_btn.text = self.label_finish
 
         self.buttons = [self.next_btn, self.previous_btn, self.cancel_btn]
 

--- a/interrogatio/widgets/wizard.py
+++ b/interrogatio/widgets/wizard.py
@@ -270,11 +270,14 @@ class WizardDialog:
             self.error_messages = ''
             self.current_step_idx -= 1
             self.current_step = self.steps[self.current_step_idx]
+            handler = self.current_step['handler']
+            if handler and handler.is_disabled(self.answers):
+                return self.previous()
             get_app().layout.focus(self.current_step['layout'])
 
         self.set_buttons_labels()
 
-    def next(self):
+    def next(self):  # noqa: CCR001
         if self.validate():
             if self.current_step_idx < len(self.steps) - 1:
                 handler = self.current_step['handler']
@@ -297,7 +300,11 @@ class WizardDialog:
     def validate(self):
         step = self.steps[self.current_step_idx]
         handler = step['handler']
-        if handler and not handler.is_valid(self.answers) and not handler.is_disabled():
+        if (
+                handler
+                and not handler.is_valid(self.answers)
+                and not handler.is_disabled()
+        ):
             self.error_messages = ','.join(handler.errors)
             return False
         self.error_messages = ''

--- a/interrogatio/widgets/wizard.py
+++ b/interrogatio/widgets/wizard.py
@@ -255,7 +255,7 @@ class WizardDialog:
             next_step = self.steps[idx]
             next_handler = next_step['handler']
             if next_handler:
-                if not next_handler.disabled:
+                if not next_handler.is_disabled(self.answers):
                     return False
             idx += 1
 

--- a/interrogatio/widgets/wizard.py
+++ b/interrogatio/widgets/wizard.py
@@ -249,30 +249,33 @@ class WizardDialog:
                 },
             )
 
-    def enabled_steps_left(self):
+    def _check_no_next_steps(self):
         idx = self.current_step_idx + 1
         while idx <= len(self.steps) - 1:
             next_step = self.steps[idx]
             next_handler = next_step['handler']
             if next_handler:
                 if not next_handler.disabled:
-                    return True
+                    return False
             idx += 1
 
-        return False
+        return True
 
     def set_buttons_labels(self):
         if len(self.steps) == 1:
             return
+
         if self.current_step_idx == 0:
             self.buttons = [self.next_btn, self.cancel_btn]
             return
-        if self.current_step_idx == len(self.steps) - 1:
+
+        if (
+                self.current_step_idx == len(self.steps) - 1
+                or self._check_no_next_steps()
+        ):
             self.next_btn.text = self.label_finish
-        elif self.enabled_steps_left():
-            self.next_btn.text = self.label_next
         else:
-            self.next_btn.text = self.label_finish
+            self.next_btn.text = self.label_next
 
         self.buttons = [self.next_btn, self.previous_btn, self.cancel_btn]
 
@@ -302,7 +305,7 @@ class WizardDialog:
                 handler = self.current_step['handler']
                 if handler:
                     if handler.is_disabled(context=self.answers):
-                        return self.next()
+                        return self.next()  # noqa: B305
                     handler.set_context(self.answers)
                 if not self.summary or self.current_step != self.steps[-1]:
                     get_app().layout.focus(self.current_step['layout'])
@@ -317,7 +320,7 @@ class WizardDialog:
         if (
                 handler
                 and not handler.is_valid(self.answers)
-                and not handler.is_disabled()
+                and not handler.is_disabled(self.answers)
         ):
             self.error_messages = ','.join(handler.errors)
             return False

--- a/tests/core/test_dialog.py
+++ b/tests/core/test_dialog.py
@@ -33,9 +33,13 @@ def test_show_dialog(mocker):
     )
     mocked_handler = mocker.MagicMock()
     mocked_handler.get_answer.return_value = {'question': 'answer'}
+    mocked_handler.is_disabled.return_value = False
+
+    mocked_disabled_handler = mocker.MagicMock()
+    mocked_disabled_handler.is_disabled.return_value = True
     mocker.patch(
         'interrogatio.core.dialog.get_instance',
-        return_value=mocked_handler,
+        side_effect=[mocked_handler, mocked_disabled_handler],
     )
     mocked_app = mocker.MagicMock()
     mocked_app.run.return_value = True
@@ -56,7 +60,7 @@ def test_show_dialog(mocker):
         return_value=mocked_layout,
     )
 
-    args = ([{'name': 'question1'}], 'title')
+    args = ([{'name': 'question'}, {'name': 'disabled_question'}], 'title')
     kwargs = {
         'intro': 'intro',
         'summary': True,
@@ -70,7 +74,7 @@ def test_show_dialog(mocker):
 
     mocked_wz_cls.assert_called_once_with(
         'title',
-        [mocked_handler],
+        [mocked_handler, mocked_disabled_handler],
         **kwargs,
     )
     mocked_layout_cls.assert_called_once_with(mocked_wz)

--- a/tests/core/test_prompt.py
+++ b/tests/core/test_prompt.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timezone
 
+import pytest
+
+from interrogatio.core.exceptions import InvalidQuestionError
 from interrogatio.core.prompt import interrogatio
 
 
@@ -649,6 +652,7 @@ def test_date_handler_invalid_char(mock_input):
             'type': 'date',
             'message': 'message',
             'description': 'description',
+            'disabled': False,
         },
     ]
 
@@ -698,3 +702,39 @@ def test_daterange_handler(mock_input):
         'from': datetime(2020, 1, 1, tzinfo=timezone.utc),
         'to': datetime(2021, 1, 1, tzinfo=timezone.utc),
     }
+
+
+def test_disabled_handler(mock_input):
+    questions = [
+        {
+            'name': 'question',
+            'type': 'input',
+            'message': 'message',
+            'description': 'description',
+            'disabled': True,
+        },
+    ]
+
+    mock_input.send_text('this is the answer\n')
+    answers = interrogatio(questions)
+
+    assert len(answers) == 0
+
+
+def test_disabled_handler_invalid(mock_input):
+    questions = [
+        {
+            'name': 'question',
+            'type': 'input',
+            'message': 'message',
+            'description': 'description',
+            'disabled': 'not callable or boolean',
+        },
+    ]
+
+    mock_input.send_text('this is the answer\n')
+
+    with pytest.raises(InvalidQuestionError) as cv:
+        interrogatio(questions)
+
+    assert str(cv.value) == 'Disabled flag must be a boolean or callable.'

--- a/tests/widgets/test_wizard.py
+++ b/tests/widgets/test_wizard.py
@@ -18,11 +18,19 @@ def test_wizard_init_default():
             'message': 'message',
             'description': 'description',
             'validators': [{'name': 'required'}],
+            'disabled': True,
+        },
+        {
+            'name': 'question3',
+            'type': 'input',
+            'message': 'message',
+            'description': 'description',
+            'validators': [{'name': 'required'}],
         },
     ]
     handlers = [get_instance(q) for q in questions]
     wz = WizardDialog('title', handlers)
-    assert len(wz.steps) == 2
+    assert len(wz.steps) == 3
 
 
 def test_wizard_init_intro_summary():
@@ -164,17 +172,27 @@ def test_wizard_next(mocker):
             'message': 'message',
             'description': 'description',
             'validators': [{'name': 'required'}],
+            'disabled': True,
+        },
+        {
+            'name': 'question3',
+            'type': 'input',
+            'message': 'message',
+            'description': 'description',
+            'validators': [{'name': 'required'}],
+            'disabled': False,
         },
     ]
     handlers = [get_instance(q) for q in questions]
     mocked_validate = mocker.patch.object(WizardDialog, 'validate')
     wz = WizardDialog('title', handlers)
     wz.next()  # noqa: B305
-    assert wz.current_step_idx == 1
-    assert wz.current_step == wz.steps[1]
+    assert wz.current_step_idx == 2
+    assert wz.current_step == wz.steps[2]
     assert len(wz.buttons) == 3
     assert wz.previous_btn in wz.buttons
-    mocked_validate.assert_called_once()
+    mocked_validate.assert_called()
+    mocked_validate.call_count == 2
 
 
 def test_wizard_previous(mocker):
@@ -190,6 +208,14 @@ def test_wizard_previous(mocker):
         },
         {
             'name': 'question2',
+            'type': 'input',
+            'message': 'message',
+            'description': 'description',
+            'validators': [{'name': 'required'}],
+            'disabled': True,
+        },
+        {
+            'name': 'question3',
             'type': 'input',
             'message': 'message',
             'description': 'description',

--- a/tests/widgets/test_wizard.py
+++ b/tests/widgets/test_wizard.py
@@ -195,6 +195,45 @@ def test_wizard_next(mocker):
     mocked_validate.call_count == 2
 
 
+def test_wizard_next_with_disabled(mocker):
+    mocked_app = mocker.MagicMock()
+    mocker.patch('interrogatio.widgets.wizard.get_app', return_value=mocked_app)
+    questions = [
+        {
+            'name': 'question1',
+            'type': 'input',
+            'message': 'message',
+            'description': 'description',
+            'validators': [{'name': 'required'}],
+        },
+        {
+            'name': 'question2',
+            'type': 'input',
+            'message': 'message',
+            'description': 'description',
+            'validators': [{'name': 'required'}],
+        },
+        {
+            'name': 'question3',
+            'type': 'input',
+            'message': 'message',
+            'description': 'description',
+            'validators': [{'name': 'required'}],
+            'disabled': True,
+        },
+    ]
+    handlers = [get_instance(q) for q in questions]
+    mocked_validate = mocker.patch.object(WizardDialog, 'validate')
+    wz = WizardDialog('title', handlers)
+    wz.next()  # noqa: B305
+    assert wz.current_step_idx == 1
+    assert wz.current_step == wz.steps[1]
+    assert len(wz.buttons) == 3
+    assert wz.previous_btn in wz.buttons
+    assert wz.next_btn.text == wz.label_finish
+    mocked_validate.assert_called_once()
+
+
 def test_wizard_previous(mocker):
     mocked_app = mocker.MagicMock()
     mocker.patch('interrogatio.widgets.wizard.get_app', return_value=mocked_app)

--- a/tests/widgets/test_wizard.py
+++ b/tests/widgets/test_wizard.py
@@ -93,6 +93,13 @@ def test_wizard_get_steps_label():
             'description': 'description',
             'validators': [{'name': 'required'}],
         },
+        {
+            'name': 'question3',
+            'type': 'input',
+            'message': 'message',
+            'description': 'description',
+            'disabled': True,
+        },
     ]
     handlers = [get_instance(q) for q in questions]
     wz = WizardDialog('title', handlers)
@@ -102,6 +109,8 @@ def test_wizard_get_steps_label():
     assert '1. Question1' == steps_lables.children[0].content.text[0][1]
     assert 'class:dialog.step ' == steps_lables.children[1].content.text[0][0]
     assert '2. Question2' == steps_lables.children[1].content.text[0][1]
+    assert 'class:dialog.step.disabled ' == steps_lables.children[2].content.text[0][0]
+    assert '3. Question3' == steps_lables.children[2].content.text[0][1]
 
 
 def test_wizard_get_status():
@@ -156,6 +165,9 @@ def test_wizard_cancel(mocker):
 
 
 def test_wizard_next(mocker):
+    def always_true(context):
+        return True
+
     mocked_app = mocker.MagicMock()
     mocker.patch('interrogatio.widgets.wizard.get_app', return_value=mocked_app)
     questions = [
@@ -172,7 +184,7 @@ def test_wizard_next(mocker):
             'message': 'message',
             'description': 'description',
             'validators': [{'name': 'required'}],
-            'disabled': True,
+            'disabled': always_true,
         },
         {
             'name': 'question3',
@@ -191,6 +203,7 @@ def test_wizard_next(mocker):
     assert wz.current_step == wz.steps[2]
     assert len(wz.buttons) == 3
     assert wz.previous_btn in wz.buttons
+    assert wz.next_btn.text == wz.label_finish
     assert mocked_validate.call_count == 2
 
 
@@ -254,6 +267,13 @@ def test_wizard_previous(mocker):
         },
         {
             'name': 'question3',
+            'type': 'input',
+            'message': 'message',
+            'description': 'description',
+            'validators': [{'name': 'required'}],
+        },
+        {
+            'name': 'question4',
             'type': 'input',
             'message': 'message',
             'description': 'description',

--- a/tests/widgets/test_wizard.py
+++ b/tests/widgets/test_wizard.py
@@ -109,7 +109,7 @@ def test_wizard_get_steps_label():
     assert '1. Question1' == steps_lables.children[0].content.text[0][1]
     assert 'class:dialog.step ' == steps_lables.children[1].content.text[0][0]
     assert '2. Question2' == steps_lables.children[1].content.text[0][1]
-    assert 'class:dialog.step.disabled ' == steps_lables.children[2].content.text[0][0]
+    assert 'disabled' in steps_lables.children[2].content.text[0][0]
     assert '3. Question3' == steps_lables.children[2].content.text[0][1]
 
 

--- a/tests/widgets/test_wizard.py
+++ b/tests/widgets/test_wizard.py
@@ -191,8 +191,7 @@ def test_wizard_next(mocker):
     assert wz.current_step == wz.steps[2]
     assert len(wz.buttons) == 3
     assert wz.previous_btn in wz.buttons
-    mocked_validate.assert_called()
-    mocked_validate.call_count == 2
+    assert mocked_validate.call_count == 2
 
 
 def test_wizard_next_with_disabled(mocker):


### PR DESCRIPTION
- [x] support for dialogus
- [x] support for prompt
- [x] tests
- [x] think what to do with disabled data (propose - clean up)
- [x] add fix of cases where disabled question - last or first (first disabled step - strange situation, not possible imo)

Example of questions:

```
def val_name(answers_data):
    return 'Dis' in answers_data.get('name', '')


questions = [
    {
        'name': 'name',
        'type': 'input',
        'message': "What's your name ?",
        'description': 'Please enter your full name. This field is required.',
        'validators': [{'name': 'required'}],
    },
    {
        'name': 'birth_date',
        'type': 'date',
        'message': "What's your birth date ?",
        'description': 'Enter your birth date.',
    },
    {
        'name': 'nationality',
        'type': 'selectone',
        'message': "What's your nationality ?",
        'description': 'Please choose one from the list.',
        'validators': [{'name': 'required'}],
        'values': [
            ('IT', 'Italian'),
            ('ES', 'Spanish'),
            ('UK', 'English'),
        ],
        'disabled': val_name,
    },
    {
        'name': 'languages',
        'type': 'selectmany',
        'message': "What are your favorite programming languages ?",
        'description': 'Please choose your favorites from the list.',
        'values': [
            ('py', 'Python'),
            ('cpp', 'C++'),
            ('java', 'Java'),
        ],
    },
]
```